### PR TITLE
Skip empty pages when navigating

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "txtv"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "A simple and fast terminal client for browsing Swedish Text TV"

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,8 +20,12 @@ enum PageDirection {
     Prev
 }
 
+const MIN_PAGE : i32 = 100;
+const MAX_PAGE : i32 = 801;
+
 /// Fetches & displays the given page image inline.
-fn fetch_and_show(channel: i32) -> Result<(), Box<dyn Error>> {
+/// TODO: Refator this, it looks terrible.
+fn fetch_and_show(channel: i32) -> Result<(i32, i32), Box<dyn Error>> {
     let url = format!("https://www.svt.se/text-tv/{}", channel);
     let html = reqwest::blocking::get(&url)?.text()?;
     let document = Html::parse_document(&html);
@@ -36,25 +40,33 @@ fn fetch_and_show(channel: i32) -> Result<(), Box<dyn Error>> {
         ..Default::default()
     };
     viuer::print(&img, &config)?;
-    Ok(())
+    let prev = get_page_number(&document, PageDirection::Prev, channel);
+    let next = get_page_number(&document, PageDirection::Next, channel);
+    Ok((prev, next))
 }
 
 /// Get the page number for the specified page direction.
-fn get_page_number(document: Html, page: PageDirection) -> Result<i32, Box<dyn Error>> {
-    let selector = match page {
-        PageDirection::Next => Selector::parse("[title='Nästa sida']")?,
-        PageDirection::Prev => Selector::parse("[title='Förra sidan']")?,
+fn get_page_number(document: &Html, direction: PageDirection, channel: i32) -> i32 {
+   let fallback = match direction {
+        PageDirection::Next => channel + 1,
+        PageDirection::Prev => channel - 1,
+   };
+
+    let selector = match direction {
+        PageDirection::Next => Selector::parse("[title='Nästa sida']"),
+        PageDirection::Prev => Selector::parse("[title='Förra sidan']"),
     };
 
-    let element = document.select(&selector).next().ok_or("Failed to fetch page number")?;
-    let href = element.value().attr("href").unwrap();
+    let page_number = selector
+        .ok()
+        .and_then(|sel| document.select(&sel).next())
+        .and_then(|el| el.value().attr("href"))
+        .and_then(|href| href.split('/').last())
+        .and_then(|s| s.parse::<i32>().ok())
+        .unwrap_or(fallback)
+        .clamp(MIN_PAGE, MAX_PAGE);
 
-    let parts : Vec<&str> = href.split('/').collect();
-    let page : i32 = parts.last().unwrap().parse().unwrap();
-
-    println!("{}", page);
-
-    Ok(page)
+    page_number
 }
 
 /// Prints the status line below the image, aligned to left.
@@ -116,7 +128,7 @@ fn prompt_goto(current: i32) -> Result<Option<i32>, Box<dyn Error>> {
     }
 
     if let Ok(n) = input.parse::<i32>() {
-        let page = n.clamp(100, 801);
+        let page = n.clamp(MIN_PAGE, MAX_PAGE);
         if page != current {
             return Ok(Some(page));
         }
@@ -135,49 +147,67 @@ fn print_page_not_found(page: i32) -> () {
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
-    // hide cursor
+    // Hide cursor
     execute!(io::stdout(), cursor::Hide)?;
 
     // Start page
     let mut channel = env::args()
         .nth(1)
         .and_then(|s| s.parse().ok())
-        .unwrap_or(100)
-        .clamp(100, 801);
+        .unwrap_or(MIN_PAGE)
+        .clamp(MIN_PAGE, MAX_PAGE);
+
+    // Initialize prev & next page with default values
+    let mut prev: i32 = (channel - 1).clamp(MIN_PAGE, MAX_PAGE);
+    let mut next: i32 = channel + 1.clamp(MIN_PAGE, MAX_PAGE);
 
     // Initial clear
     execute!(io::stdout(), Clear(ClearType::All), cursor::MoveTo(0, 0),)?;
-
+    
     // Initial render
-    if let Err(_) = fetch_and_show(channel) {
-        print_page_not_found(channel);
+    match fetch_and_show(channel) {
+        Ok((p, n)) => {
+            prev = p;
+            next = n;
+        },
+        Err(_) => {
+            print_page_not_found(channel);
+        }
     }
-    print_status(channel)?;
 
+    print_status(channel)?;
     enable_raw_mode()?;
     loop {
         if let Event::Key(KeyEvent { code, .. }) = read()? {
             match code {
                 KeyCode::Left => {
-                    // TODO: Implement get_page_number
-                    let new_ch = (channel - 1).max(100);
-                    if new_ch != channel {
-                        channel = new_ch;
+                    if prev != channel {
+                        channel = prev;
                         execute!(io::stdout(), Clear(ClearType::All), cursor::MoveTo(0, 0))?;
-                        if let Err(_) = fetch_and_show(channel) {
-                            print_page_not_found(channel);
+                        match fetch_and_show(channel) {
+                            Ok((p, n)) => {
+                                prev = p;
+                                next = n;
+                            },
+                            Err(_) => {
+                                print_page_not_found(channel);
+                            }
                         }
                         print_status(channel)?;
                     }
                 }
                 KeyCode::Right => {
-                    // TODO: Implement get_page_number
-                    let new_ch = (channel + 1).min(801);
-                    if new_ch != channel {
-                        channel = new_ch;
+                    if next != channel {
+                        channel = next;
                         execute!(io::stdout(), Clear(ClearType::All), cursor::MoveTo(0, 0))?;
-                        if let Err(_) = fetch_and_show(channel) {
-                           print_page_not_found(channel); 
+                        match fetch_and_show(channel) {
+                            Ok((p, n)) => {
+                                prev = p;
+                                next = n;
+                            },
+                            Err(_) => {
+                                print_page_not_found(channel);
+                            }
                         }
                         print_status(channel)?;
                     }
@@ -186,8 +216,14 @@ fn main() -> Result<(), Box<dyn Error>> {
                     if let Some(new_ch) = prompt_goto(channel)? {
                         channel = new_ch;
                         execute!(io::stdout(), Clear(ClearType::All), cursor::MoveTo(0, 0))?;
-                        if let Err(_) = fetch_and_show(channel) {
-                            print_page_not_found(channel);
+                        match fetch_and_show(channel) {
+                            Ok((p, n)) => {
+                                prev = p;
+                                next = n;
+                            },
+                            Err(_) => {
+                                print_page_not_found(channel);
+                            }
                         }
                         print_status(channel)?;
                     }
@@ -198,7 +234,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
     }
 
-    // restore state
+    // Restore state
     disable_raw_mode()?;
     execute!(io::stdout(), cursor::Show)?;
     Ok(())
@@ -215,7 +251,8 @@ mod tests {
     #[test]
     fn get_page_number_returns_next_page() {
         let document = Html::parse_document(&PAGE_NUMBERS_HTML);
-        let next_page = get_page_number(document, PageDirection::Next).unwrap();
+        let channel = 200; // Use 200 to ensure fallback is not used
+        let next_page = get_page_number(&document, PageDirection::Next, channel);
 
         assert_eq!(next_page, 103);
     }
@@ -223,8 +260,45 @@ mod tests {
     #[test]
     fn get_page_number_returns_prev_page() {
         let document = Html::parse_document(&PAGE_NUMBERS_HTML);
-        let prev_page = get_page_number(document, PageDirection::Prev).unwrap();
+        let channel = 200; // Use 200 to esnure fallback is not used
+        let prev_page = get_page_number(&document, PageDirection::Prev, channel);
 
         assert_eq!(prev_page, 101);
+    }
+
+    #[test]
+    fn get_next_page_number_when_no_page_in_html_returns_fallback_plus_one() {
+        let document = Html::parse_document("");
+        let channel = 103;
+        let next_page = get_page_number(&document, PageDirection::Next, channel);
+
+        assert_eq!(next_page, 104);
+    }
+
+    #[test]
+    fn get_prev_page_number_when_no_page_in_html_returns_fallback_minus_one() {
+        let document = Html::parse_document("");
+        let channel = 103;
+        let prev_page = get_page_number(&document, PageDirection::Prev, channel);
+
+        assert_eq!(prev_page, 102);
+    }
+
+    #[test]
+    fn get_next_page_should_not_go_above_max_page() {
+        let document = Html::parse_document("");
+        let channel = MAX_PAGE;
+        let next_page = get_page_number(&document, PageDirection::Next, channel);
+
+        assert_eq!(next_page, MAX_PAGE);
+    }
+
+    #[test]
+    fn get_prev_page_should_not_go_below_min_page() {
+        let document = Html::parse_document("");
+        let channel = MIN_PAGE;
+        let prev_page = get_page_number(&document, PageDirection::Prev, channel);
+
+        assert_eq!(prev_page, MIN_PAGE);
     }
 }


### PR DESCRIPTION
This PR adds a feature that mimics how https://www.svt.se/text-tv/100 works by skipping empty pages.

This is done by getting the values from the previous and next buttons on the page, it uses a risky selector that might change whenever so a fallback is in place in case that would happen.