### PR TITLE
Fix publish workflow: use --allow-dirty

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,6 @@ jobs:
 
       - name: Publish
         if: steps.version.outputs.changed == 'true'
-        run: cargo publish --locked
+        run: cargo publish --allow-dirty
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary
- Replace `--locked` with `--allow-dirty` in `cargo publish` to handle the `Cargo.lock` being updated during publish when the version is bumped