### PR TITLE
Add -v/--version and -h/--help CLI flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2419,7 +2419,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "txtv"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "base64",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "txtv"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 license = "MIT"
 description = "A simple and fast terminal client for browsing Swedish Text TV"

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,7 +83,46 @@ fn print_page_not_found(page: Channel) {
     );
 }
 
+fn print_version() {
+    println!("txtv {}", env!("CARGO_PKG_VERSION"));
+}
+
+fn print_help() {
+    print_version();
+    println!();
+    println!("{}", env!("CARGO_PKG_DESCRIPTION"));
+    println!();
+    println!("Usage: txtv [PAGE]");
+    println!();
+    println!("Arguments:");
+    println!("  [PAGE]  Page number to open (100–801) [default: 100]");
+    println!();
+    println!("Options:");
+    println!("  -h, --help     Print help");
+    println!("  -v, --version  Print version");
+    println!();
+    println!("Keybindings:");
+    println!("  ←        Previous page");
+    println!("  →        Next page");
+    println!("  g        Go to a specific page");
+    println!("  q        Quit");
+}
+
 fn main() -> Result<(), Box<dyn Error>> {
+    if let Some(arg) = env::args().nth(1) {
+        match arg.as_str() {
+            "-v" | "--version" => {
+                print_version();
+                return Ok(());
+            }
+            "-h" | "--help" => {
+                print_help();
+                return Ok(());
+            }
+            _ => {}
+        }
+    }
+
     execute!(io::stdout(), cursor::Hide)?;
 
     // Load initial channel from args, or default to min.


### PR DESCRIPTION
## Summary
- Add `-v` / `--version` flag that prints the version from Cargo.toml
- Add `-h` / `--help` flag that prints usage, options, and keybindings
- No new dependencies — uses `env!("CARGO_PKG_VERSION")` and `env!("CARGO_PKG_DESCRIPTION")`

## Test plan
- [ ] Run `txtv --version` and `txtv -v` — should print `txtv <version>`
- [ ] Run `txtv --help` and `txtv -h` — should print usage info
- [ ] Run `txtv` and `txtv 100` — should still work as before