### PR TITLE
fix: skip redundant fetch at page boundary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2419,7 +2419,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "txtv"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "base64",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "txtv"
-version = "1.0.4"
+version = "1.0.5"
 edition = "2021"
 license = "MIT"
 description = "A simple and fast terminal client for browsing Swedish Text TV"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,9 @@ impl TextTvPage {
     }
 
     pub fn next_page(&self) -> Result<Self, Box<dyn Error>> {
+        if self.next == self.channel {
+            return Err("Already at the last page".into());
+        }
         self.clear_screen()?;
         let page = Self::fetch(self.next)?;
         page.show()?;
@@ -166,6 +169,9 @@ impl TextTvPage {
     }
 
     pub fn prev_page(&self) -> Result<Self, Box<dyn Error>> {
+        if self.prev == self.channel {
+            return Err("Already at the first page".into());
+        }
         self.clear_screen()?;
         let page = Self::fetch(self.prev)?;
         page.show()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,8 +146,6 @@ fn main() -> Result<(), Box<dyn Error>> {
                     if let Ok(new_page) = page.prev_page() {
                         page = new_page;
                         print_status(page.channel())?;
-                    } else {
-                        print_page_not_found(page.channel());
                     }
                 }
 
@@ -155,8 +153,6 @@ fn main() -> Result<(), Box<dyn Error>> {
                     if let Ok(new_page) = page.next_page() {
                         page = new_page;
                         print_status(page.channel())?;
-                    } else {
-                        print_page_not_found(page.channel());
                     }
                 }
 


### PR DESCRIPTION
## Summary
- When at the first/last page, arrow key navigation no longer makes a redundant network request — the keypress is silently ignored instead
- `prev_page()` / `next_page()` now return early when the target page equals the current page
- Bumps version to 1.0.5

## Test plan
- [x] `cargo test` — all 6 tests pass
- [x] Run `txtv 100`, press left arrow — verify no request is made and no error is shown
- [x] Run `txtv 801`, press right arrow — verify no request is made and no error is shown
- [x] Verify normal navigation between pages still works