### PR TITLE
feat: add --mode text for text-based rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "aligned-vec"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1709,6 +1718,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2425,6 +2463,7 @@ dependencies = [
  "colored",
  "crossterm 0.29.0",
  "image",
+ "regex",
  "reqwest",
  "scraper",
  "viuer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2457,7 +2457,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "txtv"
-version = "1.0.5"
+version = "1.1.0"
 dependencies = [
  "base64",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,6 @@ reqwest = { version = "0.12.15", features = ["blocking"] }
 scraper = "0.23.1"
 base64 = "0.22.1"
 crossterm = "0.29.0"
+regex = "1"
 image = "0.25.6"
 viuer = "0.9.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "txtv"
-version = "1.0.5"
+version = "1.1.0"
 edition = "2021"
 license = "MIT"
 description = "A simple and fast terminal client for browsing Swedish Text TV"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project is inspired by the now-unmaintained [txtv by voidcase](https://gith
 ## Features
 > 🗓️ Planned | ✅ Implemented
 - Display text tv pages as images ✅
-- Plaintext mode 🗓️
+- Plaintext mode ✅
 
 ## Prerequisites
 
@@ -44,6 +44,26 @@ Open the interface by running the following command
 ```sh
 txtv
 ```
+
+Open a specific page
+```sh
+txtv 130
+```
+
+Use text mode (no image protocol required)
+```sh
+txtv --mode text
+# or
+txtv -m text
+```
+
+### Options
+
+| Flag | Description |
+|------|-------------|
+| `-m, --mode <MODE>` | Render mode: `image` (default) or `text` |
+| `-h, --help` | Print help |
+| `-v, --version` | Print version |
 
 ### Controls
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod text_renderer;
+
 use base64::{engine::general_purpose, Engine as _};
 use crossterm::{
     cursor, execute,

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,58 @@ use std::{
     error::Error,
     io::{self, Write},
 };
+use txtv::text_renderer::TextTvTextPage;
 use txtv::{Channel, TextTvPage, MIN_PAGE};
+
+enum Page {
+    Image(TextTvPage),
+    Text(TextTvTextPage),
+}
+
+impl Page {
+    fn fetch_image(channel: Channel) -> Result<Self, Box<dyn Error>> {
+        Ok(Page::Image(TextTvPage::fetch(channel)?))
+    }
+
+    fn fetch_text(channel: Channel) -> Result<Self, Box<dyn Error>> {
+        Ok(Page::Text(TextTvTextPage::fetch(channel)?))
+    }
+
+    fn show(&self) -> Result<(), Box<dyn Error>> {
+        match self {
+            Page::Image(p) => p.show(),
+            Page::Text(p) => p.show(),
+        }
+    }
+
+    fn next_page(&self) -> Result<Self, Box<dyn Error>> {
+        match self {
+            Page::Image(p) => Ok(Page::Image(p.next_page()?)),
+            Page::Text(p) => Ok(Page::Text(p.next_page()?)),
+        }
+    }
+
+    fn prev_page(&self) -> Result<Self, Box<dyn Error>> {
+        match self {
+            Page::Image(p) => Ok(Page::Image(p.prev_page()?)),
+            Page::Text(p) => Ok(Page::Text(p.prev_page()?)),
+        }
+    }
+
+    fn channel(&self) -> Channel {
+        match self {
+            Page::Image(p) => p.channel(),
+            Page::Text(p) => p.channel(),
+        }
+    }
+
+    fn clear_screen(&self) -> Result<(), Box<dyn Error>> {
+        match self {
+            Page::Image(p) => p.clear_screen(),
+            Page::Text(p) => p.clear_screen(),
+        }
+    }
+}
 
 /// Prints the status line below the image, aligned to left.
 fn print_status(channel: Channel) -> Result<(), Box<dyn Error>> {
@@ -92,12 +143,13 @@ fn print_help() {
     println!();
     println!("{}", env!("CARGO_PKG_DESCRIPTION"));
     println!();
-    println!("Usage: txtv [PAGE]");
+    println!("Usage: txtv [OPTIONS] [PAGE]");
     println!();
     println!("Arguments:");
     println!("  [PAGE]  Page number to open (100–801) [default: 100]");
     println!();
     println!("Options:");
+    println!("  --mode <MODE>  Render mode: image (default) or text");
     println!("  -h, --help     Print help");
     println!("  -v, --version  Print version");
     println!();
@@ -109,8 +161,14 @@ fn print_help() {
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
-    if let Some(arg) = env::args().nth(1) {
-        match arg.as_str() {
+    let args: Vec<String> = env::args().skip(1).collect();
+
+    let mut text_mode = false;
+    let mut page_num: Option<i32> = None;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
             "-v" | "--version" => {
                 print_version();
                 return Ok(());
@@ -119,20 +177,36 @@ fn main() -> Result<(), Box<dyn Error>> {
                 print_help();
                 return Ok(());
             }
-            _ => {}
+            "--mode" => {
+                if let Some(val) = args.get(i + 1) {
+                    if val == "text" {
+                        text_mode = true;
+                    }
+                    i += 1;
+                }
+            }
+            other => {
+                if let Ok(n) = other.parse::<i32>() {
+                    page_num = Some(n);
+                }
+            }
         }
+        i += 1;
     }
 
     execute!(io::stdout(), cursor::Hide)?;
 
-    // Load initial channel from args, or default to min.
-    let channel = env::args()
-        .nth(1)
-        .and_then(|s| s.parse::<i32>().ok())
+    let channel = page_num
         .map(Channel::new)
         .unwrap_or_else(|| Channel::new(MIN_PAGE));
 
-    let mut page = TextTvPage::fetch(channel)?;
+    let fetch = if text_mode {
+        Page::fetch_text
+    } else {
+        Page::fetch_image
+    };
+
+    let mut page = fetch(channel)?;
     page.clear_screen()?;
     page.show()?;
     print_status(page.channel())?;
@@ -159,7 +233,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 KeyCode::Char('g') => {
                     if let Some(target_channel) = prompt_goto()? {
                         page.clear_screen()?;
-                        if let Ok(new_page) = TextTvPage::fetch(target_channel) {
+                        if let Ok(new_page) = fetch(target_channel) {
                             page = new_page;
                             page.show()?;
                             print_status(page.channel())?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,7 +149,7 @@ fn print_help() {
     println!("  [PAGE]  Page number to open (100–801) [default: 100]");
     println!();
     println!("Options:");
-    println!("  --mode <MODE>  Render mode: image (default) or text");
+    println!("  -m, --mode <MODE>  Render mode: image (default) or text");
     println!("  -h, --help     Print help");
     println!("  -v, --version  Print version");
     println!();
@@ -177,7 +177,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 print_help();
                 return Ok(());
             }
-            "--mode" => {
+            "-m" | "--mode" => {
                 if let Some(val) = args.get(i + 1) {
                     if val == "text" {
                         text_mode = true;

--- a/src/text_renderer.rs
+++ b/src/text_renderer.rs
@@ -1,92 +1,121 @@
-// This is a WIP text renderer for SVT Text TV.
-// Currently not in use.
-
 use colored::Colorize;
+use crossterm::{
+    cursor, execute,
+    terminal::{Clear, ClearType},
+};
+use regex::Regex;
 use scraper::{Html, Selector};
-use std::env;
+use std::error::Error;
+use std::io;
 
-const DEFAULT_CHANNEL: i32 = 100;
+use crate::Channel;
 
 const WRAPPER_CLASS: &str = "div.TextContent_textWrapper__HaYCn";
 const HEADER_CLASS: &str = "div.TextContent_header__9h_7_";
 const TEXT_CONTENT_CLASS: &str = "div.TextContent_textContent__N_jyS";
 
-fn main() {
-    let args: Vec<String> = env::args().collect();
+#[derive(Debug)]
+pub struct TextTvTextPage {
+    channel: Channel,
+    document: Html,
+    prev: Channel,
+    next: Channel,
+}
 
-    let channel = args
-        .get(1)
-        .and_then(|arg| arg.parse().ok())
-        .unwrap_or(DEFAULT_CHANNEL);
+impl TextTvTextPage {
+    pub fn fetch(channel: Channel) -> Result<Self, Box<dyn Error>> {
+        let url = format!("https://www.svt.se/text-tv/webb/{}", channel);
+        let html = reqwest::blocking::get(&url)?.text()?;
+        let document = Html::parse_document(&html);
 
-    let req = format!("https://www.svt.se/text-tv/webb/{}", channel);
-    let resp = reqwest::blocking::get(req).unwrap().text().unwrap();
+        let prev = channel.prev_from_document(&document);
+        let next = channel.next_from_document(&document);
 
-    let document = Html::parse_document(resp.as_str());
-    let selector = Selector::parse(WRAPPER_CLASS).unwrap();
+        Ok(Self {
+            channel,
+            document,
+            prev,
+            next,
+        })
+    }
 
-    if let Some(element) = document.select(&selector).next() {
-        let selector = Selector::parse(HEADER_CLASS).unwrap();
-        if let Some(header) = element.select(&selector).next() {
-            println!("{}\n", header.text().collect::<Vec<_>>().join("\n").trim());
-        };
+    pub fn show(&self) -> Result<(), Box<dyn Error>> {
+        let selector = Selector::parse(WRAPPER_CLASS)?;
 
-        let selector = Selector::parse(TEXT_CONTENT_CLASS).unwrap();
-        if let Some(text_content) = element.select(&selector).nth(1) {
-            let raw_html = text_content.inner_html();
-
-            let segments: Vec<String> = raw_html
-                .split("</a>")
-                .map(|segment| format!("{}</a>", segment.trim().to_string()))
-                .filter(|segment| !segment.is_empty())
-                .collect();
-
-            for (idx, segment) in segments.iter().enumerate() {
-                print_segment(segment.as_str(), idx as i32);
+        if let Some(element) = self.document.select(&selector).next() {
+            let header_sel = Selector::parse(HEADER_CLASS)?;
+            let mut header_lines: Vec<String> = Vec::new();
+            if let Some(header) = element.select(&header_sel).next() {
+                let text = html_to_text(&header.inner_html());
+                for line in text.lines() {
+                    let trimmed = line.trim();
+                    if !trimmed.is_empty() {
+                        print!("{}\r\n", trimmed.bold());
+                        header_lines.push(trimmed.to_string());
+                    }
+                }
             }
-        };
-    } else {
-        println!("Content not found. Channels range from 100-801");
+
+            let content_sel = Selector::parse(TEXT_CONTENT_CLASS)?;
+            let mut prev_blank = true;
+            for text_content in element.select(&content_sel) {
+                let text = html_to_text(&text_content.inner_html());
+                for line in text.lines() {
+                    let trimmed = line.trim();
+                    if header_lines.iter().any(|h| h == trimmed) {
+                        continue;
+                    }
+                    if trimmed.is_empty() {
+                        if !prev_blank {
+                            print!("\r\n");
+                            prev_blank = true;
+                        }
+                    } else {
+                        print!("{}\r\n", trimmed.cyan());
+                        prev_blank = false;
+                    }
+                }
+            }
+        } else {
+            print!("Content not found for page {}\r\n", self.channel);
+        }
+
+        Ok(())
+    }
+
+    pub fn next_page(&self) -> Result<Self, Box<dyn Error>> {
+        if self.next == self.channel {
+            return Err("Already at the last page".into());
+        }
+        self.clear_screen()?;
+        let page = Self::fetch(self.next)?;
+        page.show()?;
+        Ok(page)
+    }
+
+    pub fn prev_page(&self) -> Result<Self, Box<dyn Error>> {
+        if self.prev == self.channel {
+            return Err("Already at the first page".into());
+        }
+        self.clear_screen()?;
+        let page = Self::fetch(self.prev)?;
+        page.show()?;
+        Ok(page)
+    }
+
+    pub fn channel(&self) -> Channel {
+        self.channel
+    }
+
+    pub fn clear_screen(&self) -> Result<(), Box<dyn Error>> {
+        execute!(io::stdout(), Clear(ClearType::All), cursor::MoveTo(0, 0))?;
+        Ok(())
     }
 }
 
-fn print_segment(segment: &str, idx: i32) {
-    let selector = Selector::parse("a").unwrap();
-    let document = Html::parse_document(segment);
-
-    let mut page_number: String = String::new();
-
-    for element in document.select(&selector) {
-        page_number = element.text().collect::<Vec<_>>().join("\n");
-    }
-
-    let content = document
-        .root_element()
-        .text()
-        .collect::<Vec<_>>()
-        .join("\n");
-
-    let content = content
-        .trim()
-        .lines()
-        .fold(Vec::new(), |mut acc, mut line| {
-            line = line.trim();
-            if !(line.is_empty() && acc.last().map_or(true, |last: &&str| last.is_empty())) {
-                if !line.contains(&page_number) {
-                    acc.push(line);
-                }
-            }
-            acc
-        })
-        .join("\n");
-
-    if idx % 2 == 0 {
-        println!("{}", content.yellow());
-    } else {
-        println!("{}", content.cyan());
-    }
-
-    // TODO: Add some cool separator thingy here
-    // example: ----------- 130 -----------
-    println!("{}", page_number);
+fn html_to_text(html: &str) -> String {
+    let br_re = Regex::new(r"<br\s*/?>").unwrap();
+    let with_newlines = br_re.replace_all(html, "\n");
+    let fragment = Html::parse_fragment(&with_newlines);
+    fragment.root_element().text().collect::<Vec<_>>().join("")
 }


### PR DESCRIPTION
## Summary
- Add `-m, --mode text` CLI flag to render pages as colored terminal text instead of inline images
- Rewrite `text_renderer.rs` from a standalone WIP binary into a proper library module integrated with the existing navigation loop
- Preserve original teletext line formatting via `<br>` to newline conversion
- Bump version to 1.1.0

## Test plan
- [x] Run `txtv --mode text` and verify text renders correctly
- [x] Run `txtv -m text 130` and verify article pages display with header and content
- [x] Navigate with arrow keys and `g` in text mode
- [x] Verify default image mode still works (`txtv`)